### PR TITLE
keyboard-updater: 2020-01-22 → 2021-07-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Note that the default U-Boot build does not do anything with LED on startup.
 >
 > It is unclear how to identify said hardware from a running system.
 
+To determine which keyboard controller you have, you will need to disassemble
+the Pinebook Pro as per [the Pine64
+wiki](https://wiki.pine64.org/wiki/Pinebook_Pro#Keyboard), and make sure that
+the IC next to the U23 marking on the main board is an **SH68F83**.
+
 ```
  $ nix-build -A pkgs.pinebookpro-keyboard-updater
  $ sudo ./result/bin/updater step-1 <iso|ansi>

--- a/keyboard-updater/default.nix
+++ b/keyboard-updater/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "pinebook-pro-keyboard-updater";
-  version = "2020-01-22";
+  version = "2021-07-28";
 
   nativeBuildInputs = [
     xxd
@@ -18,9 +18,9 @@ stdenv.mkDerivation {
   '';
 
   src = fetchFromGitHub {
-    owner = "jackhumbert";
+    owner = "dragan-simic";
     repo = "pinebook-pro-keyboard-updater";
-    rev = "10535c84ee599d3225b02a391c6eb2f9d8d5cdbe";
-    sha256 = "1kk4qzliqn1r8vfx8zdfpkpqazhxr4v2baahhgmlsblh0cm1cxnc";
+    rev = "bd8d2ea48992b3e6ddd0b9435d21b74cdcf97224";
+    hash = "sha256-3+Qsa5lk1EJrLvPSyWthqBMTqJCigbJSmnsS6hdu+w8=";
   };
 }


### PR DESCRIPTION
Bump the keyboard updater to dragan-simic/pinebook-pro-keyboard-updater@bd8d2ea48992b3e6ddd0b9435d21b74cdcf97224. The new version appears to fix the sluggishness of the touchpad, and keeps touchpad latency below 10ms. This PR resolves #30.

While this doesn't change from previous versions, it seems one version (**SH61F83**) of the keyboard controller only tolerates 8 writing cycles. The best (only) way of identifying it is to disassemble the laptop. Also, it would be nice to know/verify where that new binary blob we're flashing comes from.

- [x] Switch to latest version `2021-07-28`
- [x] Document steps to identify the **SH61F83** IC
- [ ] Test the new firmware extensively